### PR TITLE
fix: docker entrypoint/command to kube command/args

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,10 +85,10 @@ export function convert(yaml: string): string {
     const container: Iok8SApiCoreV1Container = {} as Iok8SApiCoreV1Container;
     container.name = name;
     container.image = service.image || 'PLACEHOLDER';
-    container.command = typeof service.command === 'string' ? 
+    container.args = typeof service.command === 'string' ? 
       parseCommand(service.command) : 
       service.command === null ? undefined : service.command;
-    container.entrypoint = typeof service.entrypoint === 'string' ?
+    container.command = typeof service.entrypoint === 'string' ?
       service.entrypoint.split(/\s+/) :
       service.entrypoint === null ? undefined : service.entrypoint;
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -41,11 +41,10 @@ spec:
         - name: frontend
           image: awesome/webapp
           args:
-            - echo
             - hello
             - world
           command:
-            - /bin/sh
+            - echo
           volumeMounts:
             - name: httpd-config
               mountPath: /httpd-config

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -40,10 +40,12 @@ spec:
       containers:
         - name: frontend
           image: awesome/webapp
-          command:
+          args:
             - echo
             - hello
             - world
+          command:
+            - /bin/sh
           volumeMounts:
             - name: httpd-config
               mountPath: /httpd-config

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -23,8 +23,8 @@ describe('convert', () => {
           - httpd-config
         secrets:
           - server-certificate
-        entrypoint: /bin/sh
-        command: echo hello world
+        entrypoint: echo
+        command: hello world
         deploy:
           replicas: 3
           resources:

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -23,6 +23,7 @@ describe('convert', () => {
           - httpd-config
         secrets:
           - server-certificate
+        entrypoint: /bin/sh
         command: echo hello world
         deploy:
           replicas: 3


### PR DESCRIPTION
As referred in https://github.com/CorentinTh/it-tools/pull/890#issuecomment-1951434667 :
- `entrypoint` in Docker Compose is `command` in Kubernetes
- `command` in Docker Compose is `args` in Kubernetes